### PR TITLE
Use BIGINT instead of INT for key columns.

### DIFF
--- a/ddl/orc.sql
+++ b/ddl/orc.sql
@@ -2,9 +2,9 @@ set hive.stats.autogather=true;
 set hive.stats.dbclass=fs;
 
 create table if not exists lineitem 
-(L_ORDERKEY INT,
- L_PARTKEY INT,
- L_SUPPKEY INT,
+(L_ORDERKEY BIGINT,
+ L_PARTKEY BIGINT,
+ L_SUPPKEY BIGINT,
  L_LINENUMBER INT,
  L_QUANTITY DOUBLE,
  L_EXTENDEDPRICE DOUBLE,
@@ -33,7 +33,7 @@ create table if not exists part (P_PARTKEY INT,
 STORED AS ORC TBLPROPERTIES ("orc.compress"="SNAPPY")
 ;
 
-create table if not exists supplier (S_SUPPKEY INT,
+create table if not exists supplier (S_SUPPKEY BIGINT,
  S_NAME STRING,
  S_ADDRESS STRING,
  S_NATIONKEY INT,
@@ -43,8 +43,8 @@ create table if not exists supplier (S_SUPPKEY INT,
 STORED AS ORC TBLPROPERTIES ("orc.compress"="SNAPPY")
 ;
 
-create table if not exists partsupp (PS_PARTKEY INT,
- PS_SUPPKEY INT,
+create table if not exists partsupp (PS_PARTKEY BIGINT,
+ PS_SUPPKEY BIGINT,
  PS_AVAILQTY INT,
  PS_SUPPLYCOST DOUBLE,
  PS_COMMENT STRING)
@@ -64,7 +64,7 @@ create table if not exists region (R_REGIONKEY INT,
 STORED AS ORC TBLPROPERTIES ("orc.compress"="SNAPPY")
 ;
 
-create table if not exists customer (C_CUSTKEY INT,
+create table if not exists customer (C_CUSTKEY BIGINT,
  C_NAME STRING,
  C_ADDRESS STRING,
  C_NATIONKEY INT,
@@ -75,8 +75,8 @@ create table if not exists customer (C_CUSTKEY INT,
 STORED AS ORC TBLPROPERTIES ("orc.compress"="SNAPPY")
 ;
 
-create table if not exists orders (O_ORDERKEY INT,
- O_CUSTKEY INT,
+create table if not exists orders (O_ORDERKEY BIGINT,
+ O_CUSTKEY BIGINT,
  O_ORDERSTATUS STRING,
  O_TOTALPRICE DOUBLE,
  O_ORDERDATE STRING,

--- a/ddl/text.sql
+++ b/ddl/text.sql
@@ -1,7 +1,7 @@
 create external table lineitem 
-(L_ORDERKEY INT,
- L_PARTKEY INT,
- L_SUPPKEY INT,
+(L_ORDERKEY BIGINT,
+ L_PARTKEY BIGINT,
+ L_SUPPKEY BIGINT,
  L_LINENUMBER INT,
  L_QUANTITY DOUBLE,
  L_EXTENDEDPRICE DOUBLE,
@@ -18,7 +18,7 @@ create external table lineitem
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' STORED AS TEXTFILE 
 LOCATION '${LOCATION}/lineitem';
 
-create external table part (P_PARTKEY INT,
+create external table part (P_PARTKEY BIGINT,
  P_NAME STRING,
  P_MFGR STRING,
  P_BRAND STRING,
@@ -30,7 +30,7 @@ create external table part (P_PARTKEY INT,
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' STORED AS TEXTFILE 
 LOCATION '${LOCATION}/part/';
 
-create external table supplier (S_SUPPKEY INT,
+create external table supplier (S_SUPPKEY BIGINT,
  S_NAME STRING,
  S_ADDRESS STRING,
  S_NATIONKEY INT,
@@ -40,8 +40,8 @@ create external table supplier (S_SUPPKEY INT,
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' STORED AS TEXTFILE 
 LOCATION '${LOCATION}/supplier/';
 
-create external table partsupp (PS_PARTKEY INT,
- PS_SUPPKEY INT,
+create external table partsupp (PS_PARTKEY BIGINT,
+ PS_SUPPKEY BIGINT,
  PS_AVAILQTY INT,
  PS_SUPPLYCOST DOUBLE,
  PS_COMMENT STRING)
@@ -61,7 +61,7 @@ create external table region (R_REGIONKEY INT,
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' STORED AS TEXTFILE
 LOCATION '${LOCATION}/region';
 
-create external table customer (C_CUSTKEY INT,
+create external table customer (C_CUSTKEY BIGINT,
  C_NAME STRING,
  C_ADDRESS STRING,
  C_NATIONKEY INT,
@@ -72,8 +72,8 @@ create external table customer (C_CUSTKEY INT,
 ROW FORMAT DELIMITED FIELDS TERMINATED BY '|' STORED AS TEXTFILE
 LOCATION '${LOCATION}/customer';
 
-create external table orders (O_ORDERKEY INT,
- O_CUSTKEY INT,
+create external table orders (O_ORDERKEY BIGINT,
+ O_CUSTKEY BIGINT,
  O_ORDERSTATUS STRING,
  O_TOTALPRICE DOUBLE,
  O_ORDERDATE STRING,


### PR DESCRIPTION
On TPCH 1TB scale factor and larger key columns overflow when INT is
used, so use 64BIT BIGINT instead.

According to the TPCH spec:
Comment: A common implementation of this datatype will be an integer.
However, for SF greater than 300 some
column values will exceed the range of integer values supported by a
4-byte integer. A test sponsor may use some
other datatype such as 8-byte integer, decimal or character string to
implement the identifier datatype;
